### PR TITLE
Add finish book: Software Architecture: The Hard Parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Reviews the IT or any books slowly and steady.
 
-## Book list of 2026 (3 book)
+## Book list of 2026 (4 book)
 
 |Title|Duration|History|Title|Duration|History|
 |-----|--------|-------|-----|--------|-------|
-|  |  |  | [![요즘 개발자를 위한 시스템 설계 수업](https://image.aladin.co.kr/product/37231/42/cover500/k292031803_1.jpg)](http://aladin.kr/p/ACHc8) | 2025-12-09 to 2026-01-30 | [IssuesLink](https://github.com/jongfeel/BookReview/issues/1560) |
+| [![Software Architecture: The Hard Parts](https://image.aladin.co.kr/product/30231/14/cover500/k972839408_1.jpg)](http://aladin.kr/p/LQw7E) | 2026-01-02 to 2026-03-21 | [IssuesLink](https://github.com/jongfeel/BookReview/issues/1575) | [![요즘 개발자를 위한 시스템 설계 수업](https://image.aladin.co.kr/product/37231/42/cover500/k292031803_1.jpg)](http://aladin.kr/p/ACHc8) | 2025-12-09 to 2026-01-30 | [IssuesLink](https://github.com/jongfeel/BookReview/issues/1560) |
 | [![Head First Software Architecture](https://image.aladin.co.kr/product/37179/38/cover500/k882031780_1.jpg)](http://aladin.kr/p/iCcy7) | 2025-09-29 to 2026-01-21 | [IssuesLink](https://github.com/jongfeel/BookReview/issues/1546) | [![실리콘밸리에선 어떻게 일하나요](https://image.aladin.co.kr/product/30176/20/cover500/k842839793_1.jpg)](http://aladin.kr/p/4fwFc) | 2025-12-17 to 2026-01-15 | [IssuesLink](https://github.com/jongfeel/BookReview/issues/1566) |
 
 ## Book list of 2025 (25 books)


### PR DESCRIPTION
## Summary

- **Book**: Software Architecture: The Hard Parts
- **Duration**: 2026-01-02 to 2026-03-21
- **Placement**: Book list of **2026** table (end date 2026-03-21 → year 2026), Step B — filled column 0 (left) of the existing top row. End date 2026-03-21 is later than the existing col 1 entry (요즘 개발자를 위한 시스템 설계 수업, 2026-01-30), completing the pair.
- 2026 book count updated from 3 to **4 book**

Closes #1575

🤖 Generated with [Claude Code](https://claude.com/claude-code)